### PR TITLE
Fix the destructuring demo name

### DIFF
--- a/examples/1 - AST/b - Destructing AST/dune
+++ b/examples/1 - AST/b - Destructing AST/dune
@@ -1,5 +1,5 @@
 (executable
- (name destructing_ast)
+ (name destructuring_ast)
  (public_name destructing_ast_demo)
  (libraries ppxlib ppxlib.astlib)
  (preprocess


### PR DESCRIPTION
## Description

I changed it to before on examples and dune and forgot to change it on the file 😓 
Thank you, @Khady, for the CI that alerted it.